### PR TITLE
LPS-97542 There are cases where the fragment entry doesn't exist in the DB, such as when it's a contributed fragment, so control this

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
@@ -431,7 +431,10 @@ public class LayoutPageTemplateEntryStagedModelDataHandler
 				_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
 					assetDisplayPageEntryId);
 
-			if (existingAssetDisplayPageEntry != null) {
+			if ((existingAssetDisplayPageEntry != null) &&
+				(existingAssetDisplayPageEntry.getGroupId() ==
+					importedLayoutPageTemplateEntry.getGroupId())) {
+
 				existingAssetDisplayPageEntry.setLayoutPageTemplateEntryId(
 					importedLayoutPageTemplateEntry.
 						getLayoutPageTemplateEntryId());

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -34,9 +34,11 @@ import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleManager;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.lar.PermissionImporter;
+import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.layout.admin.web.internal.exportimport.data.handler.util.LayoutPageTemplateStructureDataHandlerUtil;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
@@ -1266,6 +1268,22 @@ public class LayoutStagedModelDataHandler
 			userId, importedLayout, assetCategoryIds, assetTagNames);
 	}
 
+	protected void importFragmentEntry(
+			PortletDataContext portletDataContext,
+			FragmentEntryLink fragmentEntryLink)
+		throws Exception {
+
+		String path = ExportImportPathUtil.getModelPath(
+			fragmentEntryLink.getGroupId(), FragmentEntry.class.getName(),
+			fragmentEntryLink.getFragmentEntryId());
+
+		FragmentEntry fragmentEntry =
+			(FragmentEntry)portletDataContext.getZipEntryAsObject(path);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, fragmentEntry);
+	}
+
 	protected void importFragmentEntryLinks(
 			PortletDataContext portletDataContext, Layout layout,
 			Layout importedLayout)
@@ -1291,6 +1309,8 @@ public class LayoutStagedModelDataHandler
 			fragmentEntryLink.setClassNameId(
 				_portal.getClassNameId(Layout.class));
 			fragmentEntryLink.setClassPK(importedLayout.getPlid());
+
+			importFragmentEntry(portletDataContext, fragmentEntryLink);
 
 			StagedModelDataHandlerUtil.importStagedModel(
 				portletDataContext, fragmentEntryLink);
@@ -1986,7 +2006,7 @@ public class LayoutStagedModelDataHandler
 
 	private void _exportLayoutPageTemplateStructure(
 			PortletDataContext portletDataContext, Layout layout)
-		throws PortletDataException {
+		throws PortalException {
 
 		List<FragmentEntryLink> fragmentEntryLinks =
 			_fragmentEntryLinkLocalService.getFragmentEntryLinks(
@@ -1996,6 +2016,14 @@ public class LayoutStagedModelDataHandler
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
 			StagedModelDataHandlerUtil.exportReferenceStagedModel(
 				portletDataContext, layout, fragmentEntryLink,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+
+			FragmentEntry fragmentEntry =
+				_fragmentEntryLocalService.getFragmentEntry(
+					fragmentEntryLink.getFragmentEntryId());
+
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				portletDataContext, fragmentEntryLink, fragmentEntry,
 				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
 		}
 
@@ -2077,6 +2105,9 @@ public class LayoutStagedModelDataHandler
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private FragmentEntryLocalService _fragmentEntryLocalService;
 
 	private GroupLocalService _groupLocalService;
 	private ImageLocalService _imageLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -1271,7 +1271,7 @@ public class LayoutStagedModelDataHandler
 	protected void importFragmentEntry(
 			PortletDataContext portletDataContext,
 			FragmentEntryLink fragmentEntryLink)
-		throws Exception {
+		throws PortletDataException {
 
 		String path = ExportImportPathUtil.getModelPath(
 			fragmentEntryLink.getGroupId(), FragmentEntry.class.getName(),
@@ -1280,8 +1280,10 @@ public class LayoutStagedModelDataHandler
 		FragmentEntry fragmentEntry =
 			(FragmentEntry)portletDataContext.getZipEntryAsObject(path);
 
-		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, fragmentEntry);
+		if (fragmentEntry != null) {
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, fragmentEntry);
+		}
 	}
 
 	protected void importFragmentEntryLinks(
@@ -2019,12 +2021,14 @@ public class LayoutStagedModelDataHandler
 				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
 
 			FragmentEntry fragmentEntry =
-				_fragmentEntryLocalService.getFragmentEntry(
+				_fragmentEntryLocalService.fetchFragmentEntry(
 					fragmentEntryLink.getFragmentEntryId());
 
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, fragmentEntryLink, fragmentEntry,
-				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+			if (fragmentEntry != null) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, fragmentEntryLink, fragmentEntry,
+					PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+			}
 		}
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =


### PR DESCRIPTION
Hi @linolaoj, I found some issues with the PR. I fixed the one with the contributed fragments since they are not persisted in the DB. I found 2 other issues and I think they are related to ExportImportPathUtil.getModelPath

I followed the steps: Create a new site, create a structure, web content, display page, etc

After this, I exported the configuration of the Asset Publisher, and also exported all the site. Then I deleted the DB, and started again.

I couldn't import the AP configuration and I got an error when importing the LAR for the public pages.

Could you please take a look at it? Otherwise I can continue looking at it tomorrow. Please let me know.

Thanks again for all the help in this!